### PR TITLE
替换 RawGit 的镜像

### DIFF
--- a/tools/rules.json
+++ b/tools/rules.json
@@ -29,17 +29,17 @@
     },
     {
       "origin": "platform.twitter.com/widgets.js",
-      "target": "cdn.rawgit.com/jiacai2050/gooreplacer/gh-pages/proxy/widgets.js",
+      "target": "cdn.jsdelivr.net/gh/jiacai2050/gooreplacer@gh-pages/proxy/widgets.js",
       "enable": true
     },
     {
       "origin": "apis.google.com/js/api.js",
-      "target": "cdn.rawgit.com/jiacai2050/gooreplacer/gh-pages/proxy/api.js",
+      "target": "cdn.jsdelivr.net/gh/jiacai2050/gooreplacer@gh-pages/proxy/api.js",
       "enable": true
     },
     {
       "origin": "apis.google.com/js/plusone.js",
-      "target": "cdn.rawgit.com/jiacai2050/gooreplacer/gh-pages/proxy/plusone.js",
+      "target": "cdn.jsdelivr.net/gh/jiacai2050/gooreplacer@gh-pages/proxy/plusone.js",
       "enable": true
     },
     {


### PR DESCRIPTION
RawGit 已经宣布不再继续提供服务及停止更新资源，并在首页上推荐使用 jsDelivr 做替代品，所以我换掉了3个目标地址。