### PR TITLE
Workaround for Firefox bugzilla:1450965

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -197,7 +197,7 @@ if (browser.runtime.getBrowserInfo) {
 }
 
 /* Add listener */
-browser.webRequest.onBeforeRequest.addListener(
+browser.webRequest.onHeadersReceived.addListener(
     handleRedirect,
     {urls: ["<all_urls>"]},
     ["blocking"]


### PR DESCRIPTION
#40 中提到的“似乎可行的用于 Firefox 的临时方案”。在我这里测试 cdnjs.com 可以正常加载。